### PR TITLE
Update to metalava 0.2.0 to fix warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ compose = "1.1.1"
 
 android-pluginGradle = "com.android.tools.build:gradle:7.2.0"
 mavenPublish-pluginGradle = "com.vanniktech:gradle-maven-publish-plugin:0.17.0"
-metalava-pluginGradle = "me.tylerbwong.gradle:metalava-gradle:0.1.9"
+metalava-pluginGradle = "me.tylerbwong.gradle:metalava-gradle:0.2.0"
 
 naver-map = "com.naver.maps:map-sdk:3.15.0"
 google-play-services-location = "com.google.android.gms:play-services-location:16.0.0"

--- a/naver-map-compose/src/androidTest/java/com/naver/maps/map/compose/ExampleInstrumentedTest.kt
+++ b/naver-map-compose/src/androidTest/java/com/naver/maps/map/compose/ExampleInstrumentedTest.kt
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class ExampleInstrumentedTest {
+internal class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.


### PR DESCRIPTION
```
> Task :naver-map-compose:metalavaGenerateSignature
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /Users/sungyong.an/.gradle/caches/transforms-3/da5fb4cd17872b11a6de9e90ba96c98d/transformed/jetified-kotlin-stdlib-jdk8-1.5.30.jar (version 1.5)
    /Users/sungyong.an/.gradle/caches/transforms-3/87d8da7d404a977f4fb085ce5384e516/transformed/jetified-kotlin-stdlib-jdk7-1.6.10.jar (version 1.6)
    /Users/sungyong.an/.gradle/caches/transforms-3/37d5e417b9959bd1fce29685ec8fb2e6/transformed/jetified-kotlin-stdlib-1.6.10.jar (version 1.6)
    /Users/sungyong.an/.gradle/caches/transforms-3/a82e4ef7fa9f07de0a309793591cc8c4/transformed/jetified-kotlin-stdlib-common-1.6.10.jar (version 1.6)
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
```