### PR TITLE
Bump play-services-location version to 21.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ metalava-pluginGradle = "me.tylerbwong.gradle:metalava-gradle:0.2.0"
 
 naver-map = "com.naver.maps:map-sdk:3.16.1"
 naver-map-clustering = "io.github.ParkSangGwon:tedclustering-naver:1.0.2"
-google-play-services-location = "com.google.android.gms:play-services-location:16.0.0"
+google-play-services-location = "com.google.android.gms:play-services-location:21.0.1"
 
 # Kotlin
 


### PR DESCRIPTION
- https://developers.google.com/android/guides/releases#november_03_2022

## Problem

- #54
- https://issuetracker.google.com/issues/255502932

## Solution: Migrate from deprecated APIs

- [`GoogleApiClient`](https://developers.google.com/android/reference/com/google/android/gms/common/api/GoogleApiClient) -> [`GoogleApiAvailability`](https://developers.google.com/android/reference/com/google/android/gms/common/GoogleApiAvailability)
   - Guide: https://developers.google.com/android/guides/api-client#check-api-availability
- [`LocationRequest`](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest) -> [`LocationRequest.Builder`](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.Builder) ([`21.0.0`](https://developers.google.com/android/guides/releases#october_13_2022))