### PR TITLE
Bump play-services-location version to 18.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ metalava-pluginGradle = { module = "me.tylerbwong.gradle.metalava:plugin", versi
 
 naver-map = "com.naver.maps:map-sdk:3.16.1"
 naver-map-clustering = "io.github.ParkSangGwon:tedclustering-naver:1.0.2"
-google-play-services-location = "com.google.android.gms:play-services-location:16.0.0"
+google-play-services-location = "com.google.android.gms:play-services-location:18.0.0"
 
 # Kotlin
 

--- a/naver-map-location/src/main/java/com/naver/maps/map/location/FusedLocationSource.kt
+++ b/naver-map-location/src/main/java/com/naver/maps/map/location/FusedLocationSource.kt
@@ -23,6 +23,7 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.location.Location
 import android.os.Bundle
+import android.os.Looper
 import com.google.android.gms.common.api.GoogleApiClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
@@ -222,12 +223,16 @@ public abstract class FusedLocationSource(private val context: Context) : Locati
                 .addConnectionCallbacks(object : GoogleApiClient.ConnectionCallbacks {
                     @SuppressLint("MissingPermission")
                     override fun onConnected(bundle: Bundle?) {
-                        val request = LocationRequest()
+                        val request = LocationRequest.create()
                         request.priority = LocationRequest.PRIORITY_HIGH_ACCURACY
                         request.interval = 1000L
                         request.fastestInterval = 1000L
                         LocationServices.getFusedLocationProviderClient(context)
-                            .requestLocationUpdates(request, locationCallback, null)
+                            .requestLocationUpdates(
+                                request,
+                                locationCallback,
+                                Looper.getMainLooper()
+                            )
                     }
 
                     override fun onConnectionSuspended(i: Int) {}


### PR DESCRIPTION
- #54 
- https://developers.google.com/android/guides/releases#february_18_2021

## Migrate from deprecated APIs
- `LocationRequest()` -> `LocationRequest.create()`