### PR TITLE
Bump play-services-location version to 21.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ mavenPublish-pluginGradle = { module = "com.vanniktech:gradle-maven-publish-plug
 metalava-pluginGradle = { module = "me.tylerbwong.gradle.metalava:plugin", version.ref = "metalava" }
 
 naver-map = "com.naver.maps:map-sdk:3.16.1"
+naver-map-location = "io.github.fornewid:naver-map-location:16.0.0"
 naver-map-clustering = "io.github.ParkSangGwon:tedclustering-naver:1.0.2"
 google-play-services-location = "com.google.android.gms:play-services-location:21.0.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ metalava-pluginGradle = { module = "me.tylerbwong.gradle.metalava:plugin", versi
 
 naver-map = "com.naver.maps:map-sdk:3.16.1"
 naver-map-clustering = "io.github.ParkSangGwon:tedclustering-naver:1.0.2"
-google-play-services-location = "com.google.android.gms:play-services-location:18.0.0"
+google-play-services-location = "com.google.android.gms:play-services-location:21.0.1"
 
 # Kotlin
 

--- a/naver-map-compose/build.gradle
+++ b/naver-map-compose/build.gradle
@@ -39,7 +39,7 @@ metalava {
 
 dependencies {
     api libs.naver.map
-    api project(':naver-map-location')
+    api libs.naver.map.location
 
     implementation libs.compose.foundation
     implementation libs.kotlin.stdlib


### PR DESCRIPTION
- #54 
- https://developers.google.com/android/guides/releases#november_03_2022
- But use **naver-map-location 16.0.0** by default

## Migrate from deprecated APIs
- [`GoogleApiClient`](https://developers.google.com/android/reference/com/google/android/gms/common/api/GoogleApiClient) -> [`GoogleApiAvailability`](https://developers.google.com/android/reference/com/google/android/gms/common/GoogleApiAvailability)
   - Guide: https://developers.google.com/android/guides/api-client#check-api-availability
- [`LocationRequest`](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest) -> [`LocationRequest.Builder`](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.Builder) ([`21.0.0`](https://developers.google.com/android/guides/releases#october_13_2022))