### PR TITLE
Make actual current CameraPositionState available via currentCameraPositionState

### DIFF
--- a/naver-map-compose/src/main/java/com/naver/maps/map/compose/NaverMap.kt
+++ b/naver-map-compose/src/main/java/com/naver/maps/map/compose/NaverMap.kt
@@ -119,7 +119,7 @@ public fun NaverMap(
                     mapUiSettings = currentUiSettings,
                 )
                 CompositionLocalProvider(
-                    LocalCameraPositionState provides cameraPositionState,
+                    LocalCameraPositionState provides currentCameraPositionState,
                     content = currentContent,
                 )
             }


### PR DESCRIPTION
- From `googlemaps/android-maps-compose` [v4.3.2](https://github.com/googlemaps/android-maps-compose/releases/tag/v4.3.2)